### PR TITLE
Updated Accounts API

### DIFF
--- a/ndnu-connect-backend/accounts/serializers.py
+++ b/ndnu-connect-backend/accounts/serializers.py
@@ -55,7 +55,7 @@ class UserSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = User
-        fields = ('email', 'first_name', 'last_name', 'phone_number', 'password', 'token',)
+        fields = ('id', 'email', 'first_name', 'last_name', 'phone_number', 'password', 'token',)
         read_only_fields = ('token',)
 
     # Update user


### PR DESCRIPTION
A request was made from the frontend team to include the user's `id` when the API calls are made in order for the user to be associated to items created from the frontend.